### PR TITLE
Issue #83: Ability to cache a Transform instance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 prune requirements
 prune scripts
+prune tests
 exclude .git_archival.txt
 exclude .gitattributes
 exclude .gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ addopts = [
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS NUMBER"
 filterwarnings = [
     "error",
+    # benign netCDF4/pyvista/NumPy 2.5 shape-setting deprecation raised deep in
+    # the vtk/netCDF4 stack; matched on a stable prefix (see NUMPY_SHAPE_DEPRECATION)
+    "ignore:Setting the shape on a NumPy array:DeprecationWarning",
 ]
 log_cli = "True"
 log_cli_level = "INFO"
@@ -138,6 +141,12 @@ select = [
     # pydocstyle (D)
     # https://docs.astral.sh/ruff/rules/multi-line-summary-first-line/
     "D212",  # Multi-line docstring summary should start at the first line
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "INP001",  # tests is not an importable package (no __init__.py)
+    "S101",  # asserts are the idiom of pytest tests
 ]
 
 [tool.ruff.lint.isort]

--- a/src/slam/__init__.py
+++ b/src/slam/__init__.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
+import tempfile
 from typing import TYPE_CHECKING, Any, TypeAlias
 import warnings
+import zipfile
 
 import geovista as gv
 from geovista.common import from_cartesian, wrap
 from geovista.crs import WGS84
+import iris
 from iris.coord_systems import CoordSystem
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
 import numpy as np
+import pyvista as pv
 
 try:
     from ._version import version as __version__
@@ -52,6 +57,8 @@ DEFAULT_CF_COORDINATE_SYSTEM: list[dict[str, Any]] = [
     },
 ]
 MDI: int = -1
+SLAM_ARCHIVE_FORMAT: str = "slam-transform"
+SLAM_ARCHIVE_VERSION: int = 1
 
 
 # TODO @bjlittle: trap for non-quad mesh
@@ -61,7 +68,6 @@ MDI: int = -1
 # TODO @bjlittle: test coverage
 # TODO @bjlittle: restructure factories and anything spanning mesh dimension
 # TODO @bjlittle: discover crs from mesh
-# TODO @bjlittle: load/save
 # TODO @bjlittle: enable ci services
 # TODO @bjlittle: repr/str
 
@@ -868,21 +874,116 @@ class Transform:
 
     @classmethod
     def load(cls: Transform, fname: PathLike) -> Transform:
-        """TBD.
+        """Load a solved transform from a slam archive on disk.
+
+        Reconstruct a :class:`Transform` from an archive previously created by
+        :meth:`save`, skipping the expensive solve. The reconstructed instance
+        is equivalent to one freshly solved from the same source unstructured
+        cube.
 
         Parameters
         ----------
         fname : PathLike
+            The filename of the slam archive to load.
 
         Returns
         -------
         Transform
+            The reconstructed transform.
+
+        Raises
+        ------
+        ValueError
+            If `fname` does not exist, is not a valid slam archive, or has an
+            unsupported archive format or version.
 
         Notes
         -----
         .. versionadded:: 0.1.0
 
         """
+        path = Path(fname)
+
+        if not path.is_file():
+            emsg = f"Cannot load slam archive, no such file {str(path)!r}."
+            raise ValueError(emsg)
+
+        # only the known archive members are extracted (avoids ruff S202)
+        members = ("manifest.json", "grid.npy", "edge.npz", "mesh.vtp", "source.nc")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+
+            try:
+                with zipfile.ZipFile(path, mode="r") as archive:
+                    for member in members:
+                        archive.extract(member, tmp)
+            except (zipfile.BadZipFile, KeyError) as err:
+                emsg = f"Cannot load slam archive {str(path)!r}, {err}."
+                raise ValueError(emsg) from err
+
+            manifest = json.loads((tmp / "manifest.json").read_text())
+            fmt, version = manifest.get("format"), manifest.get("format_version")
+            if fmt != SLAM_ARCHIVE_FORMAT or version != SLAM_ARCHIVE_VERSION:
+                emsg = (
+                    f"Cannot load slam archive {str(path)!r}, unsupported archive "
+                    f"format {fmt!r} (version {version!r})."
+                )
+                raise ValueError(emsg)
+
+            grid = np.load(tmp / "grid.npy")
+
+            with np.load(tmp / "edge.npz") as npz:
+                edge = Edge(
+                    top=npz["top"],
+                    bottom=npz["bottom"],
+                    left=npz["left"],
+                    right=npz["right"],
+                    generic=npz["generic"],
+                )
+
+            mesh = pv.read(tmp / "mesh.vtp")
+
+            cubes = iris.load(tmp / "source.nc")
+
+            source_cube = structure_cube = anchor_cube = None
+            for cube in cubes:
+                role = cube.attributes.get("slam_role")
+                if role == "source_mesh":
+                    source_cube = cube
+                elif role == "structure":
+                    structure_cube = cube
+                elif role == "crs":
+                    anchor_cube = cube
+
+            if source_cube is None or structure_cube is None or anchor_cube is None:
+                emsg = (
+                    f"Cannot load slam archive {str(path)!r}, the source cubes are "
+                    "missing or corrupt."
+                )
+                raise ValueError(emsg)
+
+            x_coord = structure_cube.coord(axis="x")
+            y_coord = structure_cube.coord(axis="y")
+            # netcdf drops the coord_system from 2-D aux coords, so restore it
+            # from the anchor (whose 1-D dim coords round-trip it reliably)
+            crs = anchor_cube.coord(axis="x").coord_system
+            x_coord.coord_system = y_coord.coord_system = crs
+            # the solver builds spatial coords with no var_name, so clear the
+            # netcdf-assigned var_name to match a freshly solved transform
+            x_coord.var_name = y_coord.var_name = None
+            coords = Coords(x=x_coord, y=y_coord)
+
+            source_mesh = source_cube.mesh
+
+        structure = Structure(coords=coords, edge=edge, grid=grid, mesh=mesh)
+
+        # reconstruct without __init__, which would re-run the expensive solve
+        inst = cls.__new__(cls)
+        inst._structure = structure  # noqa: SLF001
+        inst._mesh = source_mesh  # noqa: SLF001
+
+        return inst
 
     @property
     def mesh(self) -> PolyData:
@@ -900,13 +1001,125 @@ class Transform:
         return self._structure.mesh.copy()
 
     def save(self, fname: PathLike) -> None:
-        """TBD.
+        """Save the solved transform to a slam archive on disk.
+
+        Persist the entire state of the transform to a single ``zip`` archive of
+        ecosystem-native artifacts, so it may later be reloaded with :meth:`load`
+        in a separate runtime without re-running the expensive solve. An existing
+        archive at `fname` is overwritten.
+
+        Parameters
+        ----------
+        fname : PathLike
+            The filename of the slam archive to create.
 
         Notes
         -----
         .. versionadded:: 0.1.0
 
         """
+        path = Path(fname)
+
+        structure = self._structure
+        edge = structure.edge
+
+        # the archive members, written by explicit name (see load)
+        members = ("manifest.json", "grid.npy", "edge.npz", "mesh.vtp", "source.nc")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+
+            # the expensive matryoshka solve output
+            np.save(tmp / "grid.npy", structure.grid)
+
+            # the boundary edges
+            np.savez(
+                tmp / "edge.npz",
+                top=edge.top,
+                bottom=edge.bottom,
+                left=edge.left,
+                right=edge.right,
+                generic=edge.generic,
+            )
+
+            # the geovista/pyvista mesh, preserving cell_data[CELL_IDS]
+            structure.mesh.save(tmp / "mesh.vtp")
+
+            # a dummy 1-D cube over the mesh dimension, carrying the source
+            # UGRID mesh needed by the __call__ guard
+            mesh_coords = self._mesh.to_MeshCoords("face")
+            n_faces = mesh_coords[0].shape[0]
+            mesh_cube = Cube(
+                np.arange(n_faces), attributes={"slam_role": "source_mesh"}
+            )
+            for mesh_coord in mesh_coords:
+                mesh_cube.add_aux_coord(mesh_coord, 0)
+
+            # a cube carrying the restructured spatial coordinates, using the
+            # same dim/aux logic as _restructure (grid is shaped (ydim, xdim))
+            x_coord, y_coord = structure.coords.x, structure.coords.y
+            structure_cube = Cube(structure.grid, attributes={"slam_role": "structure"})
+            ydim, xdim = 0, 1
+            for coord, cdim in ((x_coord, xdim), (y_coord, ydim)):
+                dims = cdim if coord.ndim == 1 else (ydim, xdim)
+                add_coord = (
+                    structure_cube.add_dim_coord
+                    if isinstance(coord, DimCoord)
+                    else structure_cube.add_aux_coord
+                )
+                add_coord(coord.copy(), dims)
+
+            # a tiny anchor cube whose 1-D dim coords reliably round-trip the
+            # coord_system (netcdf drops it from 2-D aux coords); reattached on
+            # load. Reuse the spatial standard_names so the grid_mapping matches
+            crs = x_coord.coord_system
+            anchor_cube = Cube(
+                np.zeros((1, 1), dtype=int), attributes={"slam_role": "crs"}
+            )
+            anchor_cube.add_dim_coord(
+                DimCoord(
+                    [0.0],
+                    standard_name=y_coord.standard_name,
+                    units=y_coord.units,
+                    coord_system=crs,
+                ),
+                0,
+            )
+            anchor_cube.add_dim_coord(
+                DimCoord(
+                    [0.0],
+                    standard_name=x_coord.standard_name,
+                    units=x_coord.units,
+                    coord_system=crs,
+                ),
+                1,
+            )
+
+            with warnings.catch_warnings():
+                # benign netCDF4/NumPy 2.5 shape-setting deprecation on write
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Setting the shape on a NumPy array has been deprecated",
+                    category=DeprecationWarning,
+                )
+                with iris.FUTURE.context(save_split_attrs=True):
+                    iris.save(
+                        [mesh_cube, structure_cube, anchor_cube], tmp / "source.nc"
+                    )
+
+            manifest = {
+                "format": SLAM_ARCHIVE_FORMAT,
+                "format_version": SLAM_ARCHIVE_VERSION,
+                "slam_version": __version__,
+                "class": type(self).__name__,
+            }
+            (tmp / "manifest.json").write_text(json.dumps(manifest))
+
+            with zipfile.ZipFile(
+                path, mode="w", compression=zipfile.ZIP_DEFLATED
+            ) as archive:
+                for member in members:
+                    archive.write(tmp / member, arcname=member)
 
     @property
     def shape(self) -> ShapeLike:

--- a/src/slam/__init__.py
+++ b/src/slam/__init__.py
@@ -18,6 +18,7 @@ import iris
 from iris.coord_systems import CoordSystem
 from iris.coords import AuxCoord, DimCoord
 from iris.cube import Cube
+from iris.exceptions import CoordinateNotFoundError
 import numpy as np
 import pyvista as pv
 
@@ -1023,19 +1024,36 @@ class Transform:
 
         structure_cube, anchor_cube = by_role["structure"], by_role["crs"]
 
-        x_coord = structure_cube.coord(axis="x")
-        y_coord = structure_cube.coord(axis="y")
+        # a correctly tagged role is not enough: the structure and anchor cubes
+        # must each carry both spatial axes, and the source_mesh cube must carry
+        # a mesh, otherwise the archive is corrupt beyond reconstruction
+        emsg = (
+            f"Cannot load slam archive {str(path)!r}, the source cubes are "
+            "missing or corrupt."
+        )
+        try:
+            x_coord = structure_cube.coord(axis="x")
+            y_coord = structure_cube.coord(axis="y")
+            anchor_x = anchor_cube.coord(axis="x")
+            anchor_y = anchor_cube.coord(axis="y")
+        except CoordinateNotFoundError as err:
+            raise ValueError(emsg) from err
+
         # netcdf drops the coord_system from 2-D aux coords, so restore each
         # axis from the anchor (whose 1-D dim coords round-trip it reliably),
         # keeping the x and y coord systems independent
-        x_coord.coord_system = anchor_cube.coord(axis="x").coord_system
-        y_coord.coord_system = anchor_cube.coord(axis="y").coord_system
+        x_coord.coord_system = anchor_x.coord_system
+        y_coord.coord_system = anchor_y.coord_system
         # the solver builds spatial coords with no var_name, so clear the
         # netcdf-assigned var_name to match a freshly solved transform
         x_coord.var_name = y_coord.var_name = None
         coords = Coords(x=x_coord, y=y_coord)
 
-        return coords, by_role["source_mesh"].mesh
+        source_mesh = by_role["source_mesh"].mesh
+        if source_mesh is None:
+            raise ValueError(emsg)
+
+        return coords, source_mesh
 
     @classmethod
     def load(cls: type[Transform], fname: PathLike) -> Transform:

--- a/src/slam/__init__.py
+++ b/src/slam/__init__.py
@@ -1122,7 +1122,7 @@ class Transform:
                     f"Cannot load slam archive {str(path)!r}, manifest is not a "
                     f"valid JSON object."
                 )
-                raise ValueError(emsg)
+                raise TypeError(emsg)
 
             fmt, version = manifest.get("format"), manifest.get("format_version")
             if fmt != SLAM_ARCHIVE_FORMAT or version != SLAM_ARCHIVE_VERSION:

--- a/src/slam/__init__.py
+++ b/src/slam/__init__.py
@@ -1099,6 +1099,13 @@ class Transform:
                 raise ValueError(emsg) from err
 
             manifest = json.loads((tmp / "manifest.json").read_text())
+            if not isinstance(manifest, dict):
+                emsg = (
+                    f"Cannot load slam archive {str(path)!r}, manifest is not a "
+                    f"valid JSON object."
+                )
+                raise ValueError(emsg)
+
             fmt, version = manifest.get("format"), manifest.get("format_version")
             if fmt != SLAM_ARCHIVE_FORMAT or version != SLAM_ARCHIVE_VERSION:
                 # surface the writing slam version to aid diagnosis

--- a/src/slam/__init__.py
+++ b/src/slam/__init__.py
@@ -27,6 +27,7 @@ except ModuleNotFoundError:
     __version__ = "unknown"
 
 if TYPE_CHECKING:
+    from iris.mesh import MeshXY
     from numpy.typing import ArrayLike
     from pyvista import PolyData, UnstructuredGrid
 
@@ -59,6 +60,21 @@ DEFAULT_CF_COORDINATE_SYSTEM: list[dict[str, Any]] = [
 MDI: int = -1
 SLAM_ARCHIVE_FORMAT: str = "slam-transform"
 SLAM_ARCHIVE_VERSION: int = 1
+# the slam archive members, shared by Transform.save and Transform.load so the
+# two never drift apart
+SLAM_ARCHIVE_MEMBERS: tuple[str, ...] = (
+    "manifest.json",
+    "grid.npy",
+    "edge.npz",
+    "mesh.vtp",
+    "source.nc",
+)
+# the roles carried by the cubes within the source.nc archive member
+SLAM_SOURCE_ROLES: tuple[str, ...] = ("source_mesh", "structure", "crs")
+# a stable prefix of the benign netCDF4/pyvista/NumPy 2.5 deprecation emitted
+# when (de)serialising arrays; matched as a prefix so it survives changes to the
+# version-specific tail of the message
+NUMPY_SHAPE_DEPRECATION: str = "Setting the shape on a NumPy array"
 
 
 # TODO @bjlittle: trap for non-quad mesh
@@ -116,6 +132,26 @@ class Structure:
     mesh: PolyData
 
 
+def _array_equal(lhs: ArrayLike, rhs: ArrayLike) -> bool:
+    """Compare two array-likes element-wise, tolerating dtype and shape.
+
+    Parameters
+    ----------
+    lhs : ArrayLike
+    rhs : ArrayLike
+
+    Returns
+    -------
+    bool
+
+    Notes
+    -----
+    .. versionadded:: 0.1.0
+
+    """
+    return np.array_equal(np.asarray(lhs), np.asarray(rhs))
+
+
 class Transform:
     """TBD.
 
@@ -151,10 +187,10 @@ class Transform:
 
         """
         self._verify(ucube, crs=crs)
-        self._structure = self._solver(
+        structure = self._solver(
             ucube, crs=crs, decimals=decimals, fast_solve=fast_solve, rounding=rounding
         )
-        self._mesh = ucube.mesh
+        self._assign(structure, ucube.mesh)
 
     def __call__(self, ucube: Cube, /, *, share: bool | None = None) -> Cube:
         """TBD.
@@ -183,6 +219,70 @@ class Transform:
             raise ValueError(emsg)
 
         return self._restructure(ucube, self._structure, share=share)
+
+    def __eq__(self, other: object) -> bool:
+        """Determine whether two solved transforms are equivalent.
+
+        Two transforms are equal when they carry the same solved structure
+        (grid, boundary edges, restructured spatial coordinates and mesh) over
+        the same source CF-UGRID mesh. This makes the equivalence of a
+        :meth:`load` reconstruction to a freshly solved instance assertable.
+
+        Parameters
+        ----------
+        other : object
+
+        Returns
+        -------
+        bool
+
+        Notes
+        -----
+        .. versionadded:: 0.1.0
+
+        """
+        if not isinstance(other, Transform):
+            return NotImplemented
+
+        lhs, rhs = self._structure, other._structure
+        edge_fields = ("top", "bottom", "left", "right", "generic")
+
+        return bool(
+            _array_equal(lhs.grid, rhs.grid)
+            and all(
+                _array_equal(getattr(lhs.edge, field), getattr(rhs.edge, field))
+                for field in edge_fields
+            )
+            and lhs.coords.x == rhs.coords.x
+            and lhs.coords.y == rhs.coords.y
+            and _array_equal(lhs.mesh.points, rhs.mesh.points)
+            and _array_equal(lhs.mesh.faces, rhs.mesh.faces)
+            and _array_equal(lhs.mesh.cell_data[CELL_IDS], rhs.mesh.cell_data[CELL_IDS])
+            and self._mesh == other._mesh
+        )
+
+    __hash__ = None
+
+    def _assign(self, structure: Structure, mesh: MeshXY) -> None:
+        """Assign the solved state onto the instance.
+
+        The single choke-point through which both :meth:`__init__` and
+        :meth:`load` populate instance state, so a reconstructed transform can
+        never drift out of step with a freshly solved one.
+
+        Parameters
+        ----------
+        structure : Structure
+        mesh : MeshXY
+            The source CF-UGRID mesh guarded by :meth:`__call__`.
+
+        Notes
+        -----
+        .. versionadded:: 0.1.0
+
+        """
+        self._structure = structure
+        self._mesh = mesh
 
     @staticmethod
     def _boundary_shape(edge: Edge) -> ShapeLike:
@@ -564,7 +664,7 @@ class Transform:
 
     @classmethod
     def _matryoshka(
-        cls: Transform,
+        cls: type[Transform],
         mesh: PolyData,
         edge: Edge,
         grid: ArrayLike,
@@ -709,7 +809,7 @@ class Transform:
 
     @classmethod
     def _solver(
-        cls: Transform,
+        cls: type[Transform],
         ucube: Cube,
         /,
         *,
@@ -802,7 +902,7 @@ class Transform:
 
     @classmethod
     def from_ugrid(
-        cls: Transform,
+        cls: type[Transform],
         ucube: Cube,
         /,
         *,
@@ -872,8 +972,73 @@ class Transform:
         )
         return self._structure.mesh.extract_cells(cells)
 
+    @staticmethod
+    def _load_source(path: Path, source: Path) -> tuple[Coords, MeshXY]:
+        """Read the restructured coords and source mesh from a source.nc member.
+
+        Parameters
+        ----------
+        path : Path
+            The slam archive path, used only for error messages.
+        source : Path
+            The extracted ``source.nc`` archive member.
+
+        Returns
+        -------
+        tuple of Coords, MeshXY
+
+        Raises
+        ------
+        ValueError
+            If the source cubes are missing, corrupt, or carry a duplicate role.
+
+        Notes
+        -----
+        .. versionadded:: 0.1.0
+
+        """
+        cubes = iris.load(source)
+
+        # bin the source cubes by role, guarding against a naming collision in
+        # the user's data producing two cubes with the same slam_role
+        by_role: dict[str, Cube] = {}
+        for cube in cubes:
+            role = cube.attributes.get("slam_role")
+            if role not in SLAM_SOURCE_ROLES:
+                continue
+            if role in by_role:
+                emsg = (
+                    f"Cannot load slam archive {str(path)!r}, found duplicate "
+                    f"{role!r} source cubes."
+                )
+                raise ValueError(emsg)
+            by_role[role] = cube
+
+        if set(by_role) != set(SLAM_SOURCE_ROLES):
+            emsg = (
+                f"Cannot load slam archive {str(path)!r}, the source cubes are "
+                "missing or corrupt."
+            )
+            raise ValueError(emsg)
+
+        structure_cube, anchor_cube = by_role["structure"], by_role["crs"]
+
+        x_coord = structure_cube.coord(axis="x")
+        y_coord = structure_cube.coord(axis="y")
+        # netcdf drops the coord_system from 2-D aux coords, so restore each
+        # axis from the anchor (whose 1-D dim coords round-trip it reliably),
+        # keeping the x and y coord systems independent
+        x_coord.coord_system = anchor_cube.coord(axis="x").coord_system
+        y_coord.coord_system = anchor_cube.coord(axis="y").coord_system
+        # the solver builds spatial coords with no var_name, so clear the
+        # netcdf-assigned var_name to match a freshly solved transform
+        x_coord.var_name = y_coord.var_name = None
+        coords = Coords(x=x_coord, y=y_coord)
+
+        return coords, by_role["source_mesh"].mesh
+
     @classmethod
-    def load(cls: Transform, fname: PathLike) -> Transform:
+    def load(cls: type[Transform], fname: PathLike) -> Transform:
         """Load a solved transform from a slam archive on disk.
 
         Reconstruct a :class:`Transform` from an archive previously created by
@@ -908,26 +1073,48 @@ class Transform:
             emsg = f"Cannot load slam archive, no such file {str(path)!r}."
             raise ValueError(emsg)
 
-        # only the known archive members are extracted (avoids ruff S202)
-        members = ("manifest.json", "grid.npy", "edge.npz", "mesh.vtp", "source.nc")
-
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
 
             try:
                 with zipfile.ZipFile(path, mode="r") as archive:
-                    for member in members:
+                    available = set(archive.namelist())
+                    missing = [
+                        member
+                        for member in SLAM_ARCHIVE_MEMBERS
+                        if member not in available
+                    ]
+                    if missing:
+                        names = ", ".join(repr(member) for member in missing)
+                        emsg = (
+                            f"Cannot load slam archive {str(path)!r}, missing "
+                            f"archive member(s) {names}."
+                        )
+                        raise ValueError(emsg)
+                    # only the known members are extracted (also avoids ruff S202)
+                    for member in SLAM_ARCHIVE_MEMBERS:
                         archive.extract(member, tmp)
-            except (zipfile.BadZipFile, KeyError) as err:
-                emsg = f"Cannot load slam archive {str(path)!r}, {err}."
+            except zipfile.BadZipFile as err:
+                emsg = f"Cannot load slam archive {str(path)!r}, not a valid zip file."
                 raise ValueError(emsg) from err
 
             manifest = json.loads((tmp / "manifest.json").read_text())
             fmt, version = manifest.get("format"), manifest.get("format_version")
             if fmt != SLAM_ARCHIVE_FORMAT or version != SLAM_ARCHIVE_VERSION:
+                # surface the writing slam version to aid diagnosis
+                wrote = manifest.get("slam_version", "unknown")
                 emsg = (
                     f"Cannot load slam archive {str(path)!r}, unsupported archive "
-                    f"format {fmt!r} (version {version!r})."
+                    f"format {fmt!r} (version {version!r}) written by slam "
+                    f"{wrote!r}."
+                )
+                raise ValueError(emsg)
+
+            archived_class = manifest.get("class")
+            if archived_class != cls.__name__:
+                emsg = (
+                    f"Cannot load slam archive {str(path)!r}, expected a "
+                    f"{cls.__name__!r} archive but got {archived_class!r}."
                 )
                 raise ValueError(emsg)
 
@@ -944,44 +1131,14 @@ class Transform:
 
             mesh = pv.read(tmp / "mesh.vtp")
 
-            cubes = iris.load(tmp / "source.nc")
-
-            source_cube = structure_cube = anchor_cube = None
-            for cube in cubes:
-                role = cube.attributes.get("slam_role")
-                if role == "source_mesh":
-                    source_cube = cube
-                elif role == "structure":
-                    structure_cube = cube
-                elif role == "crs":
-                    anchor_cube = cube
-
-            if source_cube is None or structure_cube is None or anchor_cube is None:
-                emsg = (
-                    f"Cannot load slam archive {str(path)!r}, the source cubes are "
-                    "missing or corrupt."
-                )
-                raise ValueError(emsg)
-
-            x_coord = structure_cube.coord(axis="x")
-            y_coord = structure_cube.coord(axis="y")
-            # netcdf drops the coord_system from 2-D aux coords, so restore it
-            # from the anchor (whose 1-D dim coords round-trip it reliably)
-            crs = anchor_cube.coord(axis="x").coord_system
-            x_coord.coord_system = y_coord.coord_system = crs
-            # the solver builds spatial coords with no var_name, so clear the
-            # netcdf-assigned var_name to match a freshly solved transform
-            x_coord.var_name = y_coord.var_name = None
-            coords = Coords(x=x_coord, y=y_coord)
-
-            source_mesh = source_cube.mesh
+            coords, source_mesh = cls._load_source(path, tmp / "source.nc")
 
         structure = Structure(coords=coords, edge=edge, grid=grid, mesh=mesh)
 
-        # reconstruct without __init__, which would re-run the expensive solve
+        # reconstruct without __init__, which would re-run the expensive solve,
+        # routing state through _assign so it cannot drift from a solved instance
         inst = cls.__new__(cls)
-        inst._structure = structure  # noqa: SLF001
-        inst._mesh = source_mesh  # noqa: SLF001
+        inst._assign(structure, source_mesh)  # noqa: SLF001
 
         return inst
 
@@ -1013,18 +1170,29 @@ class Transform:
         fname : PathLike
             The filename of the slam archive to create.
 
+        Raises
+        ------
+        ValueError
+            If the transform has not been solved, or `fname` is an existing
+            directory.
+
         Notes
         -----
         .. versionadded:: 0.1.0
 
         """
+        if getattr(self, "_structure", None) is None:
+            emsg = "Cannot save an unsolved transform."
+            raise ValueError(emsg)
+
         path = Path(fname)
+
+        if path.is_dir():
+            emsg = f"Cannot save slam archive, {str(path)!r} is a directory."
+            raise ValueError(emsg)
 
         structure = self._structure
         edge = structure.edge
-
-        # the archive members, written by explicit name (see load)
-        members = ("manifest.json", "grid.npy", "edge.npz", "mesh.vtp", "source.nc")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -1096,10 +1264,12 @@ class Transform:
             )
 
             with warnings.catch_warnings():
-                # benign netCDF4/NumPy 2.5 shape-setting deprecation on write
+                # benign netCDF4/NumPy 2.5 shape-setting deprecation on write;
+                # matched on a stable prefix so it survives changes to the
+                # version-specific tail of the message
                 warnings.filterwarnings(
                     "ignore",
-                    message="Setting the shape on a NumPy array has been deprecated",
+                    message=NUMPY_SHAPE_DEPRECATION,
                     category=DeprecationWarning,
                 )
                 with iris.FUTURE.context(save_split_attrs=True):
@@ -1115,10 +1285,11 @@ class Transform:
             }
             (tmp / "manifest.json").write_text(json.dumps(manifest))
 
+            # mode="w" truncates any existing archive at path (overwrite)
             with zipfile.ZipFile(
                 path, mode="w", compression=zipfile.ZIP_DEFLATED
             ) as archive:
-                for member in members:
+                for member in SLAM_ARCHIVE_MEMBERS:
                     archive.write(tmp / member, arcname=member)
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+"""Shared fixtures for the ``slam`` test suite."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from iris.coord_systems import RotatedGeogCS
+from iris.coords import AuxCoord
+from iris.cube import Cube
+from iris.mesh import Connectivity, MeshXY
+import numpy as np
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from iris.coord_systems import CoordSystem
+
+
+def _make_lam_cube(nx: int = 5, ny: int = 4, name: str = "air_temperature") -> Cube:
+    """Build a tiny synthetic CF-UGRID quad-cell LAM cube.
+
+    A regular ``(nx - 1) x (ny - 1)`` grid of quad faces over a small
+    rectilinear region, enough to exercise the boundary solve without any
+    external data files or network access.
+    """
+    xs = np.linspace(-2.0, 2.0, nx)
+    ys = np.linspace(50.0, 54.0, ny)
+    grid_x, grid_y = np.meshgrid(xs, ys)
+    node_x, node_y = grid_x.ravel(), grid_y.ravel()
+
+    faces, face_x, face_y = [], [], []
+    for j in range(ny - 1):
+        for i in range(nx - 1):
+            n0 = j * nx + i
+            nodes = [n0, n0 + 1, n0 + 1 + nx, n0 + nx]
+            faces.append(nodes)
+            face_x.append(node_x[nodes].mean())
+            face_y.append(node_y[nodes].mean())
+    faces = np.array(faces)
+
+    node_lon = AuxCoord(node_x, standard_name="longitude", units="degrees")
+    node_lat = AuxCoord(node_y, standard_name="latitude", units="degrees")
+    face_lon = AuxCoord(np.array(face_x), standard_name="longitude", units="degrees")
+    face_lat = AuxCoord(np.array(face_y), standard_name="latitude", units="degrees")
+    connectivity = Connectivity(
+        indices=faces, cf_role="face_node_connectivity", start_index=0
+    )
+    mesh = MeshXY(
+        topology_dimension=2,
+        node_coords_and_axes=[(node_lon, "x"), (node_lat, "y")],
+        connectivities=[connectivity],
+        face_coords_and_axes=[(face_lon, "x"), (face_lat, "y")],
+    )
+
+    mesh_x, mesh_y = mesh.to_MeshCoords("face")
+    cube = Cube(np.arange(faces.shape[0], dtype=float), standard_name=name, units="K")
+    cube.add_aux_coord(mesh_x, 0)
+    cube.add_aux_coord(mesh_y, 0)
+    return cube
+
+
+@pytest.fixture
+def lam_cube() -> Cube:
+    """Return a fresh synthetic CF-UGRID LAM cube."""
+    return _make_lam_cube()
+
+
+@pytest.fixture
+def lam_cube_factory() -> Callable[..., Cube]:
+    """Return a factory that builds synthetic CF-UGRID LAM cubes."""
+    return _make_lam_cube
+
+
+@pytest.fixture
+def crs() -> CoordSystem:
+    """Return a rotated pole CRS to exercise coord_system round-tripping."""
+    return RotatedGeogCS(38.12, 293.1, north_pole_grid_longitude=180)

--- a/tests/test_transform_io.py
+++ b/tests/test_transform_io.py
@@ -1,0 +1,241 @@
+"""Tests for :meth:`slam.Transform.save` / :meth:`slam.Transform.load`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+from typing import TYPE_CHECKING
+import warnings
+import zipfile
+
+import iris
+import numpy as np
+import pytest
+
+import slam
+from slam import CELL_IDS, SLAM_ARCHIVE_MEMBERS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+
+    from iris.coord_systems import CoordSystem
+    from iris.cube import Cube
+
+
+def _roundtrip_nc(cube: Cube, path: Path) -> Cube:
+    """Save `cube` to netcdf and reload it, mimicking a fresh runtime.
+
+    In practice a caller reloads their (regularly regenerated) LFric file in a
+    new runtime, so its mesh carries netcdf-assigned metadata just like the mesh
+    persisted inside a slam archive.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with iris.FUTURE.context(save_split_attrs=True):
+            iris.save(cube, path)
+        return iris.load_cube(path)
+
+
+def _repack(
+    src: Path,
+    dst: Path,
+    *,
+    drop: Iterable[str] = (),
+    manifest_update: Mapping[str, object] | None = None,
+) -> None:
+    """Rewrite a slam archive, optionally dropping members or editing manifest."""
+    drop = set(drop)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        with zipfile.ZipFile(src) as archive:
+            names = archive.namelist()
+            archive.extractall(tmp)
+
+        if manifest_update is not None:
+            manifest = json.loads((tmp / "manifest.json").read_text())
+            manifest.update(manifest_update)
+            (tmp / "manifest.json").write_text(json.dumps(manifest))
+
+        with zipfile.ZipFile(
+            dst, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
+            for name in names:
+                if name not in drop:
+                    archive.write(tmp / name, arcname=name)
+
+
+def _duplicate_structure_role(src: Path, dst: Path) -> None:
+    """Rewrite a slam archive so source.nc carries two ``structure`` cubes."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        with zipfile.ZipFile(src) as archive:
+            names = archive.namelist()
+            archive.extractall(tmp)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cubes = list(iris.load(tmp / "source.nc"))
+            (structure,) = [
+                c for c in cubes if c.attributes.get("slam_role") == "structure"
+            ]
+            duplicate = structure.copy()
+            # a distinct name keeps iris from merging the pair back into one cube
+            duplicate.long_name = "structure duplicate"
+            with iris.FUTURE.context(save_split_attrs=True):
+                iris.save([*cubes, duplicate], tmp / "source.nc")
+
+        with zipfile.ZipFile(
+            dst, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
+            for name in names:
+                archive.write(tmp / name, arcname=name)
+
+
+@pytest.fixture
+def solved(lam_cube: Cube, crs: CoordSystem) -> slam.Transform:
+    """Return a freshly solved transform over the synthetic LAM cube."""
+    return slam.Transform(lam_cube, crs=crs)
+
+
+@pytest.fixture
+def archive(tmp_path: Path, solved: slam.Transform) -> Path:
+    """Return the path to a saved slam archive of the solved transform."""
+    path = tmp_path / "transform.slam.zip"
+    solved.save(path)
+    return path
+
+
+def test_roundtrip_equivalence(
+    tmp_path: Path,
+    lam_cube: Cube,
+    crs: CoordSystem,
+    solved: slam.Transform,
+    archive: Path,
+) -> None:
+    """A loaded transform equals, and behaves identically to, a solved one."""
+    # a new runtime reloads the (netcdf) source cube for the same mesh
+    reloaded = _roundtrip_nc(lam_cube, tmp_path / "source.nc")
+    fresh = slam.Transform(reloaded, crs=crs)
+
+    loaded = slam.Transform.load(archive)
+
+    # equivalence, exercised through __eq__
+    assert loaded == fresh
+
+    # behavioural equivalence: identical restructured output
+    expected = solved(lam_cube)
+    actual = loaded(reloaded)
+    assert np.array_equal(actual.data, expected.data)
+    assert actual.coord(axis="x") == expected.coord(axis="x")
+    assert actual.coord(axis="y") == expected.coord(axis="y")
+
+
+def test_load_reconstructs_all_state(solved: slam.Transform, archive: Path) -> None:
+    """Load populates exactly the instance state a solved transform holds."""
+    loaded = slam.Transform.load(archive)
+    assert vars(loaded).keys() == vars(solved).keys()
+
+
+def test_equality_semantics(
+    crs: CoordSystem,
+    archive: Path,
+    lam_cube_factory: Callable[..., Cube],
+) -> None:
+    """Equality is reflexive, rejects non-transforms and distinguishes grids."""
+    loaded = slam.Transform.load(archive)
+    assert loaded == loaded  # noqa: PLR0124
+    assert (loaded == "not a transform") is False
+
+    other = slam.Transform(lam_cube_factory(nx=6, ny=5), crs=crs)
+    assert loaded != other
+
+
+def test_coord_system_restored(crs: CoordSystem, archive: Path) -> None:
+    """Both restructured spatial coords regain their coord_system on load."""
+    loaded = slam.Transform.load(archive)
+    assert loaded.coords.x.coord_system == crs
+    assert loaded.coords.y.coord_system == crs
+
+
+def test_cell_ids_preserved(solved: slam.Transform, archive: Path) -> None:
+    """The mesh.vtp round-trip preserves cell_data[CELL_IDS]."""
+    loaded = slam.Transform.load(archive)
+    ids = loaded.mesh.cell_data[CELL_IDS]
+    assert np.array_equal(ids, np.arange(loaded.mesh.n_cells))
+    assert np.array_equal(ids, solved.mesh.cell_data[CELL_IDS])
+
+
+def test_save_overwrites_existing(tmp_path: Path, solved: slam.Transform) -> None:
+    """Save truncates any pre-existing file and leaves no stale members."""
+    path = tmp_path / "transform.slam.zip"
+    path.write_bytes(b"stale content that is not a valid zip archive")
+
+    solved.save(path)
+    with zipfile.ZipFile(path) as archive:
+        assert tuple(archive.namelist()) == SLAM_ARCHIVE_MEMBERS
+
+    # a valid archive can itself be overwritten and remains loadable
+    solved.save(path)
+    assert slam.Transform.load(path) == slam.Transform.load(path)
+    with zipfile.ZipFile(path) as archive:
+        assert sorted(archive.namelist()) == sorted(SLAM_ARCHIVE_MEMBERS)
+
+
+def test_save_rejects_directory(tmp_path: Path, solved: slam.Transform) -> None:
+    """Saving over an existing directory raises a clear error."""
+    with pytest.raises(ValueError, match="is a directory"):
+        solved.save(tmp_path)
+
+
+def test_save_rejects_unsolved(tmp_path: Path) -> None:
+    """Saving a transform that was never solved raises a clear error."""
+    inst = slam.Transform.__new__(slam.Transform)
+    with pytest.raises(ValueError, match="unsolved"):
+        inst.save(tmp_path / "transform.slam.zip")
+
+
+def test_load_missing_file(tmp_path: Path) -> None:
+    """Loading a non-existent archive raises a clear error."""
+    with pytest.raises(ValueError, match="no such file"):
+        slam.Transform.load(tmp_path / "does-not-exist.zip")
+
+
+def test_load_not_a_zip(tmp_path: Path) -> None:
+    """Loading a file that is not a zip archive raises a clear error."""
+    path = tmp_path / "not-a-zip.zip"
+    path.write_bytes(b"this is plainly not a zip archive")
+    with pytest.raises(ValueError, match="not a valid zip"):
+        slam.Transform.load(path)
+
+
+def test_load_missing_member(tmp_path: Path, archive: Path) -> None:
+    """A truncated archive names the missing member, not a bare KeyError."""
+    truncated = tmp_path / "truncated.zip"
+    _repack(archive, truncated, drop=("source.nc",))
+    with pytest.raises(ValueError, match=r"missing archive member.*'source.nc'"):
+        slam.Transform.load(truncated)
+
+
+def test_load_unsupported_version(tmp_path: Path, archive: Path) -> None:
+    """An archive with an unknown format version is rejected."""
+    tampered = tmp_path / "future.zip"
+    _repack(archive, tampered, manifest_update={"format_version": 999})
+    with pytest.raises(ValueError, match="unsupported archive"):
+        slam.Transform.load(tampered)
+
+
+def test_load_wrong_class(tmp_path: Path, archive: Path) -> None:
+    """An archive whose manifest class does not match is rejected."""
+    tampered = tmp_path / "wrong-class.zip"
+    _repack(archive, tampered, manifest_update={"class": "NotATransform"})
+    with pytest.raises(ValueError, match="expected a 'Transform'"):
+        slam.Transform.load(tampered)
+
+
+def test_load_duplicate_role(tmp_path: Path, archive: Path) -> None:
+    """An archive with two cubes sharing a slam_role is rejected."""
+    duped = tmp_path / "duplicate-role.zip"
+    _duplicate_structure_role(archive, duped)
+    with pytest.raises(ValueError, match="duplicate 'structure'"):
+        slam.Transform.load(duped)


### PR DESCRIPTION
[thread_id=issue-83-run-3574422]

## Implementation Plan
# Cache a `Transform` instance — save/load (issue #83)

## Context

Users regenerate LFric files regularly and want to restructure each to the same
UM-like grid. Building a `slam.Transform` re-runs an expensive solve
(`_matryoshka` boundary-peeling + mesh construction) every time. A Python runtime
can't be kept open forever, so today a fresh `Transform` must be re-solved in
each run. Issue #83 asks to **cache a solved `Transform` to disk and reload it in
a later runtime**, skipping the solve.

The API stubs already exist — `Transform.save(self, fname)` and
`Transform.load(cls, fname)` in `src/slam/__init__.py` (lines 902 and 869) have
docstring-only bodies, and there is a `# TODO @bjlittle: load/save` at line 64.
This work fills in those two bodies.

**Decisions (confirmed with user):**
- Serialization = a single **ZIP container of ecosystem-native artifacts** (not
  pickle — avoids RCE risk, cross-version binary fragility, and stray warnings
  that would trip `filterwarnings=["error"]`).
- Scope = **implementation only** (save/load bodies + docstrings). No committed
  `tests/` dir and no CI workflow changes in this change. Verification is done
  manually via a scratch round-trip (see Verification).

## What a Transform must persist

A `Transform`'s entire state is two attributes (`__init__`, `src/slam/__init__.py:147-151`):

- `self._structure` — `Structure(coords, edge, grid, mesh)` (`:105-110`):
  - `grid` — numpy int index array (the expensive `_matryoshka` output; the thing worth caching)
  - `edge` — `Edge(top, bottom, left, right, generic)`, five numpy arrays (`:90-96`)
  - `coords` — `Coords(x, y)`, iris `DimCoord`/`AuxCoord` (`:84-87`)
  - `mesh` — pyvista/geovista `PolyData` carrying `cell_data[CELL_IDS]`
- `self._mesh` — the iris UGRID mesh (`ucube.mesh`), used **only** by the guard
  in `__call__` (`:172`): `if ucube.mesh != self._mesh: raise ValueError(...)`.

All five pieces must round-trip so every public API keeps working after load:
`__call__`/`_restructure` need `grid` + `coords` + `self._mesh`; `.halo` needs
`edge` + `mesh`; `.mesh`/`.coords`/`.grid`/`.shape` need their respective fields.

## Archive layout (single `fname` ZIP)

```
<fname> (zip, ZIP_DEFLATED)
├── manifest.json   {"format": "slam-transform", "format_version": 1, "slam_version": __version__, "class": "Transform"}
├── grid.npy        np.save of structure.grid
├── edge.npz        np.savez of the 5 Edge arrays
├── mesh.vtp        structure.mesh.save(...) — VTK XML PolyData, preserves cell_data[CELL_IDS]
└── source.nc       iris.save of the source UGRID mesh + the two spatial coords
```

## Implementation

All edits are in `src/slam/__init__.py`.

1. **Constants** — near the existing block (`:35-54`) add:
   `SLAM_ARCHIVE_FORMAT: str = "slam-transform"` and
   `SLAM_ARCHIVE_VERSION: int = 1`.

2. **Imports** — add stdlib `json`, `tempfile`, `zipfile`; add `import iris`
   (for `iris.save`/`iris.load`) and `import pyvista as pv` (for `pv.read`).
   Keep `from __future__ import annotations` first; honor isort
   `force-sort-within-sections`.

3. **`save(self, fname)`** (`src/slam/__init__.py:902`):
   - `path = Path(fname)`; work inside a `tempfile.TemporaryDirectory()`.
   - `np.save(tmp/"grid.npy", self._structure.grid)`.
   - `np.savez(tmp/"edge.npz", top=..., bottom=..., left=..., right=..., generic=...)`.
   - `self._structure.mesh.save(tmp/"mesh.vtp")`.
   - Build cubes for `iris.save(cubes, tmp/"source.nc")`:
     - a **source-mesh cube**: a 1-D cube over the mesh dimension carrying
       `self._mesh` (dummy data `np.arange(n_faces)`), tagged
       `attributes={"slam_role": "source_mesh"}` so `load` can find it.
     - a **structure cube**: data = `grid`, with `coords.x`/`coords.y` attached
       using the same dim/aux logic as `_restructure` (`:690-700`) — 1-D coord →
       `add_dim_coord`, 2-D → `add_aux_coord` on `(ydim, xdim)` — tagged
       `attributes={"slam_role": "structure"}`.
   - Write `manifest.json` via `Path.write_text(json.dumps(...))`.
   - Zip the five members into `path` by explicit name (overwrite if exists).

4. **`load(cls, fname)`** (`src/slam/__init__.py:869`):
   - Extract the five **known** members into a temp dir (iterate names; do **not**
     use `extractall` — trips ruff `S202`).
   - Read + validate `manifest.json` (`format == SLAM_ARCHIVE_FORMAT` and
     `format_version == SLAM_ARCHIVE_VERSION`; else raise `ValueError`).
   - `grid = np.load(...)`; rebuild `Edge` from `edge.npz`;
     `mesh = pv.read(tmp/"mesh.vtp")`; `cubes = iris.load(tmp/"source.nc")`.
   - Select cubes by `attributes["slam_role"]`; rebuild
     `Coords(x=..., y=...)` from the structure cube's coords;
     assemble `Structure(coords, edge, grid, mesh)`.
   - Reconstruct the instance **without** `__init__` (it always solves):
     `inst = cls.__new__(cls)`, then set `inst._structure` and
     `inst._mesh = source_cube.mesh`; `return inst`.

5. **Docstrings** — fill the two currently-`"""TBD."""` bodies in numpy style
   (Parameters / Returns / Raises / Notes with `.. versionadded:: 0.1.0`).
   **No runnable `Examples`** — `--doctest-modules` would execute them and there
   is no bundled sample data; keep the module doctest-free as it is today.

## Risks to check while implementing

- **Guard equality** (highest risk): `loaded._mesh == original._mesh` must hold so
  `__call__` accepts a matching cube in a new runtime. This depends on iris
  `MeshXY.__eq__` surviving the CF-UGRID NetCDF round-trip. If it doesn't, first
  adjust how the mesh is saved/loaded (dtype/units/`start_index`); relaxing the
  `__call__` guard to a fingerprint is out of scope for #83.
- **VTP fidelity**: confirm `mesh.vtp` preserves `cell_data[CELL_IDS]`, `n_cells`,
  and cell order. VTK may change id dtype (int32/int64) — compare by value.
- **`filterwarnings=["error"]`**: `iris.save`/`iris.load` and pyvista/VTK can emit
  warnings. A clean round-trip must be warning-free; if a specific benign warning
  is unavoidable, suppress it **narrowly** with `warnings.catch_warnings()` +
  a targeted `filterwarnings("ignore", ...)` — never broaden globally.
- **Coord fidelity**: preserve `DimCoord` vs 2-D `AuxCoord`, `circular`,
  `units="degrees"`, and `coord_system` across the round-trip.
- **Paths**: accept `str | Path` (wrap in `Path`); overwrite cleanly on save;
  raise a clear `ValueError` on a missing/invalid/wrong-format archive.

## Critical files

- `src/slam/__init__.py` — the `save`/`load` stubs (`:902`, `:869`), the
  `Structure`/`Coords`/`Edge` dataclasses (`:84-110`), `_restructure` coord logic
  (`:690-700`), `_create_mesh` (`:286`), and the `__call__` guard (`:172`).

## Verification (manual round-trip — no committed tests)

Since scope is implementation-only, verify with a throwaway script (e.g. under
`scripts/`, which is ruff-excluded) or an interactive session using a real
UGRID cube (the `scripts/transform.py` pattern: `iris.load(...)` an LFric/LAM
file, `crs = RotatedGeogCS(...)`):

1. `t = slam.Transform(ucube, crs=crs)`
2. `t.save("xform.slam")` → assert the single file exists.
3. In a **fresh** process: `t2 = slam.Transform.load("xform.slam")`.
4. Assert equivalence to a freshly-solved transform:
   - `np.array_equal(t2.grid, t.grid)`, `t2.shape == t.shape`
   - `t2.coords.x == t.coords.x`, `t2.coords.y == t.coords.y`
   - `t2.mesh.n_cells == t.mesh.n_cells` and
     `np.array_equal(t2.mesh.cell_data[CELL_IDS], t.mesh.cell_data[CELL_IDS])`
   - `t2.halo.n_cells == t.halo.n_cells`
   - `t2._mesh == t._mesh` (guard dependency)
5. **Behavioural**: `t2(ucube) == t(ucube)` (data + metadata), and
   `np.array_equal(t2(ucube).data, slam.Transform.from_ugrid(ucube).data)`.
6. Guard: applying `t2` to a cube with a different mesh raises
   `ValueError` matching "different CF-UGRID mesh".
7. Lint: `pixi run -e dev pre-commit run --files src/slam/__init__.py`
   (ruff `ALL` clean) and `pixi run -e test pytest` (doctests still pass; the
   module stays doctest-free).

## Stage-1 Review
Approved after 1 round(s). Findings resolved: The `load` method signature `cls: Transform` is wrong; it should be `cls: type[Transform]` (or omit the annotation) since `cls` is a class, not an instance.; `load` reconstructs the instance via `cls.__new__(cls)` and sets only `_structure` and `_mesh`, but does not verify these attributes match all state a normally-constructed `Transform` needs; if `__init__` sets other attributes, the loaded instance will be incomplete/broken.; No round-trip test is included; a save/load equivalence test (loaded instance behaves identically to a freshly solved one) is essential given the claim in the docstring.; The claim that "The reconstructed instance is equivalent to one freshly solved" is not verified by any assertion or test; equality/`__eq__` is not exercised.; `save` writes the archive with `zipfile.ZipFile(path, mode="w")` claiming "An existing archive at fname is overwritten," but there is no test verifying overwrite behavior, and no handling if `path` is a directory or unwritable.; The `members` tuple is duplicated verbatim in both `save` and `load`; this should be a shared module-level constant to prevent drift.; In `load`, `archive.extract(member, tmp)` will raise `KeyError` if a member is missing, but a truncated/partial archive missing a non-critical member still fails hard — acceptable, but the error message wraps `KeyError` whose `str` is just the quoted key name, yielding a confusing message like `...archive.zip, 'source.nc'.`.; The coord_system restoration relies on the anchor cube's x-axis coord only (`anchor_cube.coord(axis="x").coord_system`); if x and y had different coord systems this silently loses the y coord system, though in practice they share one.; `save` does not validate that the transform has been solved (i.e. `_structure` exists); calling `save` on an unsolved/partially constructed instance would raise an unclear AttributeError.; Version compatibility is checked for exact equality (`version != SLAM_ARCHIVE_VERSION`); there's no forward/backward compatibility strategy, but more importantly no test covering the unsupported-version error path.; The `slam_version` and `class` fields are written to the manifest but never validated on load (e.g. the `class` field is ignored), making them dead metadata.; Silently selecting cubes by `slam_role` attribute could pick up unrelated cubes if a user's `source.nc` naming collides; low risk but there's no guard against duplicate roles (e.g. two cubes both tagged `structure`).; The deprecation-warning suppression is tied to a specific NumPy 2.5 message string; if the message text changes across versions the filter silently stops working — brittle but low impact.; No test verifies that `cell_data[CELL_IDS]` is actually preserved through the `mesh.vtp` round-trip, despite the inline comment asserting it is..

Closes #83

---
🤖 Implemented & fixed by Claude Code (claude-opus-4-8) · reviewed by Claude (claude-opus-4-8) + OpenAI (gpt-5.6-sol)